### PR TITLE
added seg fault warning

### DIFF
--- a/openfermionpsi4/_run_psi4.py
+++ b/openfermionpsi4/_run_psi4.py
@@ -214,5 +214,10 @@ def run_psi4(molecule,
         clean_up(molecule, delete_input, delete_output)
 
     # Return updated molecule instance.
-    molecule.load()
+    try:
+        molecule.load()
+    except:
+        print('No calculation saved. Psi4 segmentation fault possible.')
+        if not tolerate_error:
+            raise
     return molecule

--- a/openfermionpsi4/_run_psi4.py
+++ b/openfermionpsi4/_run_psi4.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 import os
 import re
 import subprocess
+import warnings
 
 
 def create_geometry_string(geometry):
@@ -217,7 +218,6 @@ def run_psi4(molecule,
     try:
         molecule.load()
     except:
-        print('No calculation saved. Psi4 segmentation fault possible.')
-        if not tolerate_error:
-            raise
+        warnings.warn('No calculation saved. Psi4 segmentation fault possible.',
+                      Warning)
     return molecule


### PR DESCRIPTION
I had a very frustrating experience where I was getting seg faults in psi4 but the way it showed up was to just notify me that the calculation never saved. These couple of lines will hopefully make this issue more transparent to users in the future.