### PR TITLE
Up version for new pypi

### DIFF
--- a/openfermionpsi4/_version.py
+++ b/openfermionpsi4/_version.py
@@ -15,4 +15,4 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "0.4"
+__version__ = "0.5"


### PR DESCRIPTION
It seems we missed cutting the v0.4 release on Github.  Thus
when I made the v0.4 not realizing v0.4 was pushed to pypi I created
a naming issue.  Pypi releases must have unique versions.

My solution is to uplevel everything to v0.5 such that the new pypi
version will be 0.1 + 0.4 (the current pypi version).