### PR TITLE
improve exception handling in run_psi4

### DIFF
--- a/openfermionpsi4/_run_psi4.py
+++ b/openfermionpsi4/_run_psi4.py
@@ -208,9 +208,12 @@ def run_psi4(molecule,
     try:
         process = subprocess.Popen(['psi4', input_file, output_file])
         process.wait()
-    except:
-        print('Psi4 calculation for {} has failed.'.format(molecule.name))
-        process.kill()
+    except Exception as ex:
+        print('Psi4 calculation for {} has failed. ({})'.format(molecule.name, ex))
+        try:
+            process.kill()
+        except:
+            pass
         clean_up(molecule, delete_input, delete_output)
         if not tolerate_error:
             raise


### PR DESCRIPTION
When `Psi4` is not installed an exception occurs because the file `psi4` cannot be found. Cleanup of the process with `process.kill()` then generates another exception, because the variable `process` was not created. 

This PR:

* Adds the generated exception to the warning message
* Wraps the `process.kill()` in a `try-except`
